### PR TITLE
Make nodes data also available as CSV

### DIFF
--- a/cmd/toxstatus/assets/templates/base.html
+++ b/cmd/toxstatus/assets/templates/base.html
@@ -28,7 +28,7 @@
 	<footer class="footer">
 		<div class="container">
 			<a class="text-muted pull-left" href="/json">JSON</a>
-      <div class="text-muted pull-left"> | </div>
+			<div class="text-muted pull-left"> | </div>
 			<a class="text-muted pull-left" href="/csv">CSV</a>
 			<a class="text-muted pull-right" target="_blank" href="https://github.com/Tox/ToxStatus">I'm open source!</a>
 			<p class="text-muted text-center">{{ template "footer" . }}</p>

--- a/cmd/toxstatus/assets/templates/base.html
+++ b/cmd/toxstatus/assets/templates/base.html
@@ -28,6 +28,8 @@
 	<footer class="footer">
 		<div class="container">
 			<a class="text-muted pull-left" href="/json">JSON</a>
+      <div class="text-muted pull-left"> | </div>
+			<a class="text-muted pull-left" href="/csv">CSV</a>
 			<a class="text-muted pull-right" target="_blank" href="https://github.com/Tox/ToxStatus">I'm open source!</a>
 			<p class="text-muted text-center">{{ template "footer" . }}</p>
 		</div>

--- a/cmd/toxstatus/main.go
+++ b/cmd/toxstatus/main.go
@@ -78,6 +78,7 @@ func main() {
 	serveMux.HandleFunc("/", handleHTTPRequest)
 	serveMux.Handle("/test", tollbooth.LimitFuncHandler(limiter, handleHTTPRequest))
 	serveMux.HandleFunc("/json", handleJSONRequest)
+	serveMux.HandleFunc("/csv", handleCSVRequest)
 	go func() {
 		err := http.Serve(listener, serveMux)
 		if err != nil {

--- a/cmd/toxstatus/web.go
+++ b/cmd/toxstatus/web.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"encoding/json"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -179,26 +179,25 @@ func writeJSONResponse(w http.ResponseWriter, content interface{}) {
 	w.Write(bytes)
 }
 
-
 func writeCSVResponse(w http.ResponseWriter, content *toxStatus) {
 	w.Header().Set("Content-Type", "text/csv")
-  w2 := csv.NewWriter(w)
-  for _, obj := range content.Nodes {
-    var record []string
-    record = append(record, obj.Ipv4Address)
-    record = append(record, obj.Ipv6Address)
-    record = append(record, strconv.Itoa(obj.Port))
-    record = append(record, obj.PublicKey)
-    record = append(record, obj.Maintainer)
-    record = append(record, obj.Location)
-    record = append(record, strconv.FormatBool(obj.UDPStatus))
-    record = append(record, strconv.FormatBool(obj.TCPStatus))
-    record = append(record, obj.Version)
-    record = append(record, obj.MOTD)
-    record = append(record, strconv.FormatInt(obj.LastPing, 10))
-    w2.Write(record)
-  }
-  w2.Flush()
+	w2 := csv.NewWriter(w)
+	for _, obj := range content.Nodes {
+		var record []string
+		record = append(record, obj.Ipv4Address)
+		record = append(record, obj.Ipv6Address)
+		record = append(record, strconv.Itoa(obj.Port))
+		record = append(record, obj.PublicKey)
+		record = append(record, obj.Maintainer)
+		record = append(record, obj.Location)
+		record = append(record, strconv.FormatBool(obj.UDPStatus))
+		record = append(record, strconv.FormatBool(obj.TCPStatus))
+		record = append(record, obj.Version)
+		record = append(record, obj.MOTD)
+		record = append(record, strconv.FormatInt(obj.LastPing, 10))
+		w2.Write(record)
+	}
+	w2.Flush()
 }
 
 func parseNodes() ([]*toxNode, error) {

--- a/cmd/toxstatus/web.go
+++ b/cmd/toxstatus/web.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"encoding/csv"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -162,6 +163,11 @@ func handleJSONRequest(w http.ResponseWriter, r *http.Request) {
 	writeJSONResponse(w, content)
 }
 
+func handleCSVRequest(w http.ResponseWriter, r *http.Request) {
+	content := getState()
+	writeCSVResponse(w, content)
+}
+
 func writeJSONResponse(w http.ResponseWriter, content interface{}) {
 	bytes, err := json.Marshal(content)
 	if err != nil {
@@ -171,6 +177,28 @@ func writeJSONResponse(w http.ResponseWriter, content interface{}) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(bytes)
+}
+
+
+func writeCSVResponse(w http.ResponseWriter, content *toxStatus) {
+	w.Header().Set("Content-Type", "text/csv")
+  w2 := csv.NewWriter(w)
+  for _, obj := range content.Nodes {
+    var record []string
+    record = append(record, obj.Ipv4Address)
+    record = append(record, obj.Ipv6Address)
+    record = append(record, strconv.Itoa(obj.Port))
+    record = append(record, obj.PublicKey)
+    record = append(record, obj.Maintainer)
+    record = append(record, obj.Location)
+    record = append(record, strconv.FormatBool(obj.UDPStatus))
+    record = append(record, strconv.FormatBool(obj.TCPStatus))
+    record = append(record, obj.Version)
+    record = append(record, obj.MOTD)
+    record = append(record, strconv.FormatInt(obj.LastPing, 10))
+    w2.Write(record)
+  }
+  w2.Flush()
 }
 
 func parseNodes() ([]*toxNode, error) {


### PR DESCRIPTION
It leaves me in a bit of confused mind state, why data were present in the _extremely machine-unfriendly_ JSON and not in the some kind of very convenient table format (CSV or TSV). Even more so, taking into account the fact that they have table-ish origin (wiki page), it's just strange.

Fixed that.